### PR TITLE
Minor visual tweaks

### DIFF
--- a/src/components/Legend.jsx
+++ b/src/components/Legend.jsx
@@ -39,7 +39,13 @@ export const Legend = ({ activeQuestion }) => {
 
 export const LegendPane = ({ activeQuestion }) => {
   return (
-    <Box w='lg' p={2} paddingInlineStart={4} overflowY='scroll'>
+    <Box
+      w='lg'
+      p={4}
+      pe={2}
+      overflowY='scroll'
+      boxShadow='inset 0px 11px 8px -10px #CCC, inset 0px -11px 8px -10px #CCC'
+    >
       <Heading size='md' align='center' >Legend</Heading>
       <Legend activeQuestion={activeQuestion} />
     </Box>

--- a/src/components/QuestionMenuBar.jsx
+++ b/src/components/QuestionMenuBar.jsx
@@ -21,7 +21,15 @@ export default function QuestionMenuBar({
   });
 
   return (
-    <Flex minH='140px' p='10px' gap='10px' overflowY='hidden' overflowX='auto'>
+    <Flex
+      minH='140px'
+      py='10px'
+      gap='10px'
+      overflowY='hidden'
+      overflowX='auto'
+      _before={{ content:'""', margin: 'auto' }}
+      _after={{ content:'""', margin: 'auto' }}
+    >
       {questionButtons}
     </Flex>
   )


### PR DESCRIPTION
Center the QuestionMenu buttons when screen is wider than all the icons.

Add slight inner box shadow to top and bottom of LegendPane to distinguish it.