### PR TITLE
Add layers to Naturehood default off

### DIFF
--- a/src/data/layers/StewardshipGroups.jsx
+++ b/src/data/layers/StewardshipGroups.jsx
@@ -30,7 +30,7 @@ const layer = {
     }
   },
   questions: [
-    { key: 'neighbourhood-to-naturehood', group: 'default', active: true },
+    { key: 'neighbourhood-to-naturehood', group: 'default', active: false },
     { key: 'development', group: 'Nature', active: false },
   ]
 }

--- a/src/data/layers/TreeCoverage2005.jsx
+++ b/src/data/layers/TreeCoverage2005.jsx
@@ -30,6 +30,7 @@ const layer = {
   styleMap: styleMap_TreeCoverage2005,
   questions: [
     { key: 'beat-the-heat', group: 'default', active: true },
+    { key: 'neighbourhood-to-naturehood', group: 'default', active: false },
     { key: 'development', group: 'Nature', active: false },
   ]
 }

--- a/src/data/layers/Watersheds.jsx
+++ b/src/data/layers/Watersheds.jsx
@@ -42,6 +42,7 @@ const layer = {
   },
   questions: [
     { key: 'protect-from-flooding', group: 'default', active: true },
+    { key: 'neighbourhood-to-naturehood', group: 'default', active: false },
     { key: 'development', group: 'Water', active: false },
   ]
 }


### PR DESCRIPTION
Add Tree Coverage and Watersheds as optional layers to Naturehood, and set Stewardship Groups to default off as well.