### PR TITLE
Content size changes to reduce mobile padding

### DIFF
--- a/src/components/ContentPane.jsx
+++ b/src/components/ContentPane.jsx
@@ -34,7 +34,10 @@ export default function ContentPane({question, ...props}) {
         overflow='auto'
         alignItems='center'
       >
-        <Box maxW='6xl' px='60px'>
+        <Box
+          maxW='6xl'
+          px={{base: '12px', md:'60px'}}
+        >
           <Box pb='2em'>
             <FormattedText textArray={Questions.get(question).description} />
           </Box>


### PR DESCRIPTION
Reduced left and right padding on ContentPane to 12px below 'md' size breakpoint.